### PR TITLE
fix: repo name scheme to prevent accidental pipe

### DIFF
--- a/r2e/repo_builder/setup_repos.py
+++ b/r2e/repo_builder/setup_repos.py
@@ -49,7 +49,7 @@ class SetupRepos:
         repo_username, repo_name = (
             repo_url.rstrip("/").removesuffix(".git").split("/")[-2:]
         )
-        local_repo_clone_path = REPOS_DIR / f"{repo_username}|{repo_name}"
+        local_repo_clone_path = REPOS_DIR / f"{repo_username}_{repo_name}"
 
         if os.path.exists(local_repo_clone_path):
             print(
@@ -66,7 +66,7 @@ class SetupRepos:
         local_repo_path = str(Path(local_repo_path).resolve())
 
         local_repo_name = local_repo_path.split("/")[-1]
-        local_repo_clone_path = REPOS_DIR / f"LOCAL|{local_repo_name}"
+        local_repo_clone_path = REPOS_DIR / f"LOCAL_{local_repo_name}"
 
         if os.path.exists(local_repo_clone_path):
             print(


### PR DESCRIPTION
The cloned repository name format "REPO_AUTHOR|REPO_NAME" causes the installation process in the docker container to fail because bash reads the "|" character as a pipe and tries to execute REPO_NAME as a command. My fix is to replace "|" with "_"