### PR TITLE
feat(extract_functions): optional disabling of filters

### DIFF
--- a/r2e/pat/instrument/arguments.py
+++ b/r2e/pat/instrument/arguments.py
@@ -81,7 +81,7 @@ class CaptureArgsInstrumenter(Instrumenter):
 
         serialized_obj = Serializers.serialize_default(obj)
 
-        if isinstance(serialized_obj, Iterable) and len(serialized_obj) > 180:
+        if isinstance(serialized_obj, Iterable) and len(serialized_obj) > 180:  # type: ignore
             return serialized_obj[:90] + "  ......  " + serialized_obj[-90:]  # type: ignore
 
         return serialized_obj

--- a/r2e/repo_builder/extract_func_methods.py
+++ b/r2e/repo_builder/extract_func_methods.py
@@ -21,7 +21,7 @@ def build_functions_and_methods(repo_args: RepoArgs):
             return
 
     repo_dirs = list(REPOS_DIR.glob("*"))
-    repos = [Repo.from_file_path(str(repo_dir)) for repo_dir in repo_dirs]
+    repos = [(Repo.from_file_path(str(repo_dir)), repo_args) for repo_dir in repo_dirs]
 
     functions = []
     methods = []

--- a/r2e/repo_builder/fut_extractor/extract_repo_data.py
+++ b/r2e/repo_builder/fut_extractor/extract_repo_data.py
@@ -16,8 +16,6 @@ def extract_repo_data(args) -> tuple[list[Function], list[Method]]:
     methods: list[Method] = []
     no_filter = repo_args.disable_lines_filter or repo_args.disable_all_filters
 
-    print("SHOULD I FILTER ON LINES:", filter_lines)
-
     for file_path in repo.list_repo_files():
         if not file_path.endswith(".py"):
             continue

--- a/r2e/repo_builder/fut_extractor/extract_repo_data.py
+++ b/r2e/repo_builder/fut_extractor/extract_repo_data.py
@@ -11,7 +11,7 @@ MAX_LINES_METHOD = 20
 
 
 def extract_repo_data(args) -> tuple[list[Function], list[Method]]:
-    repo, repo_args = args  # type: Repo, RepoArgs
+    repo, repo_args = args
     functions: list[Function] = []
     methods: list[Method] = []
     no_filter = repo_args.disable_lines_filter or repo_args.disable_all_filters

--- a/r2e/repo_builder/repo_args.py
+++ b/r2e/repo_builder/repo_args.py
@@ -57,3 +57,39 @@ class RepoArgs(BaseModel):
         16,
         description="Number of processes to use for extracting functions and methods",
     )
+
+    ## extraction filter disable args (use to disable filters)
+    disable_dunder_methods: bool = Field(
+        True,
+        description="Disable dunder method filter",
+    )
+
+    disable_no_docstring: bool = Field(
+        True,
+        description="Disable functions w/o docstring filter",
+    )
+
+    disable_signature_filters: bool = Field(
+        True,
+        description="Disable function signature filters (args, returns)",
+    )
+
+    disable_keyword_filters: bool = Field(
+        True,
+        description="Disable keyword filters (docstring, body, name)",
+    )
+
+    disable_wrapper_filters: bool = Field(
+        True,
+        description="Disable filters for wrappers (decorators, etc.)",
+    )
+
+    disable_lines_filter: bool = Field(
+        True,
+        description="Disable lines filter",
+    )
+
+    disable_all_filters: bool = Field(
+        True,
+        description="Disable all filters",
+    )


### PR DESCRIPTION
This PR adds optional disable flags that can disable certain filters during function/method extractions. 
> Note: eventually this can be made enable flags, but this keeps things backward compatible.