### PR TITLE
fix: use iterative accumulation to define module path

### DIFF
--- a/r2e/models/module.py
+++ b/r2e/models/module.py
@@ -20,11 +20,31 @@ class Module(BaseModel):
 
     @property
     def local_path(self) -> str:
-        path = self.module_id.identifier.replace(".", "/")
-        if self.module_type == ModuleTypeEnum.PACKAGE:
-            return f"{self.repo.repo_path}/{path}"
-        else:
-            return f"{self.repo.repo_path}/{path}.py"
+        parts = self.module_id.identifier.split(".")
+        path = self.repo.repo_path
+        segment = ""
+
+        for i, part in enumerate(parts):
+            # accumulate a path segment until full path exists
+            segment = f"{segment}.{part}" if segment else part
+            current_path = os.path.join(path, segment)
+
+            # if the path exists, reset segment
+            if os.path.exists(current_path):
+                path = current_path
+                segment = ""
+
+            elif i == len(parts) - 1:
+                # if module is a file, check if it exists
+                if self.module_type != ModuleTypeEnum.PACKAGE:
+                    py_path = f"{current_path}.py"
+                    if os.path.exists(py_path):
+                        return py_path
+
+                # if a package, return directory
+                return os.path.join(path, segment)
+
+        return path
 
     @property
     def relative_module_path(self) -> str:


### PR DESCRIPTION
This PR updates the logic to define the local_path of a `Module` from it's identifier.

The previous version assumed that simply splitting the identifier at `'.'` and replacing with "/" suffices. However, this fails for paths and directories whose names have "." in them. E.g., `.../lib.linux-x86-xxx/...'.

Soln: iteratively create the path using the parts we get after splitting on "." while checking if partial paths exist. If not, merge parts into larger segment of the path.